### PR TITLE
HW k8s operator

### DIFF
--- a/kubernetes-operators/deploy/cr.yml
+++ b/kubernetes-operators/deploy/cr.yml
@@ -1,0 +1,9 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: mysql:5.7
+  database: otus-database
+  password: otuspassword  # Так делать не нужно, следует использовать secret
+  storage_size: 1Gi

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced     # Данный CRD будер работать в рамках namespace
+  group: otus.homework  # Группа, отражается в поле apiVersion CR
+  versions:             # Список версий
+    - name: v1
+      served: true      # Будет ли обслуживаться API-сервером данная версия
+      storage: true     # Фиксирует  версию описания, которая будет сохраняться в etcd
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+            spec:
+              type: object
+              properties:
+                image: 
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+              required:
+                - image
+                - database
+                - password
+                - storage_size        
+  names:                # различные форматы имени объекта CR
+    kind: MySQL         # kind CR
+    plural: mysqls      
+    singular: mysql
+    shortNames:
+      - ms

--- a/kubernetes-operators/deploy/crd.yml
+++ b/kubernetes-operators/deploy/crd.yml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
@@ -9,35 +9,35 @@ spec:
     - name: v1
       served: true      # Будет ли обслуживаться API-сервером данная версия
       storage: true     # Фиксирует  версию описания, которая будет сохраняться в etcd
-      schema:
-        openAPIV3Schema:
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
           type: object
           properties:
-            apiVersion:
+            name:
               type: string
-            kind:
+        spec:
+          type: object
+          properties:
+            image: 
               type: string
-            metadata:
-              type: object
-              properties:
-                name:
-                  type: string
-            spec:
-              type: object
-              properties:
-                image: 
-                  type: string
-                database:
-                  type: string
-                password:
-                  type: string
-                storage_size:
-                  type: string
-              required:
-                - image
-                - database
-                - password
-                - storage_size        
+            database:
+              type: string
+            password:
+              type: string
+            storage_size:
+              type: string
+          required:
+            - image
+            - database
+            - password
+            - storage_size        
   names:                # различные форматы имени объекта CR
     kind: MySQL         # kind CR
     plural: mysqls      

--- a/kubernetes-operators/deploy/deploy-operator.yml
+++ b/kubernetes-operators/deploy/deploy-operator.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: "zhenkins/mysql-operator:v0.1"
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role-binding.yml
+++ b/kubernetes-operators/deploy/role-binding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/role.yml
+++ b/kubernetes-operators/deploy/role.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubernetes-operators/deploy/service-account.yml
+++ b/kubernetes-operators/deploy/service-account.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
# Выполнено ДЗ №

 - [X] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 Был создан кастомный ресурс типа для mysql
 И оператор к нему, который сконфигурировал инстанс.

## вывод команды kubectl get jobs
тут у меня возникла странность. статус restore задания не меняется, но данные восстанавливаются, после удлаения вольюма.
 ```sh
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ kubectl get jobs
NAME                         COMPLETIONS   DURATION   AGE
backup-mysql-instance-job    1/1           2s         51s
restore-mysql-instance-job   0/1           19m        19m
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
mysql: [Warning] Using a password on the command line interface can be insecure.
+----+-------------+
| id | name        |
+----+-------------+
|  1 | some data   |
|  2 | some data-2 |
+----+-------------+
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ 
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ 
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ 
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ kubectl delete mysqls.otus.homework mysql-instance 
mysql.otus.homework "mysql-instance" deleted
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ kubectl get pv
NAME                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                               STORAGECLASS   REASON   AGE
backup-mysql-instance-pv   1Gi        RWO            Retain           Bound    default/backup-mysql-instance-pvc                           20m
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ 
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ 
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ kubectl get jobs
NAME                         COMPLETIONS   DURATION   AGE
backup-mysql-instance-job    1/1           2s         27s
restore-mysql-instance-job   0/1           21m        21m
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ kubectl apply -f ./cr.yml 
mysql.otus.homework/mysql-instance created
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ kubectl get pv
NAME                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                               STORAGECLASS   REASON   AGE
backup-mysql-instance-pv   1Gi        RWO            Retain           Bound    default/backup-mysql-instance-pvc                           21m
mysql-instance-pv          1Gi        RWO            Retain           Bound    default/mysql-instance-pvc                                  22s
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-databasemysql: [Warning] Using a password on the command line interface can be insecure.
+----+-------------+
| id | name        |
+----+-------------+
|  1 | some data   |
|  2 | some data-2 |
+----+-------------+
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ kubectl get jobs
NAME                         COMPLETIONS   DURATION   AGE
backup-mysql-instance-job    1/1           2s         78s
restore-mysql-instance-job   0/1           22m        22m
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ kubectl logs mysql-operator-5f8d4b579f-gkrsq
[2020-06-14 12:19:51,232] kopf.engines.peering [WARNING ] Default peering object not found, falling back to the standalone mode.
/mysql-operator.py:28: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  json_manifest = yaml.load(yaml_manifest)
[2020-06-14 12:22:21,775] kopf.objects         [INFO    ] [default/mysql-instance] Handler 'mysql_on_create' succeeded.
[2020-06-14 12:22:21,776] kopf.objects         [INFO    ] [default/mysql-instance] All handlers succeeded for creation.
[2020-06-14 12:36:18,899] kopf.objects         [INFO    ] [default/mysql-instance] Handler 'delete_object_make_backup' succeeded.
[2020-06-14 12:36:18,900] kopf.objects         [INFO    ] [default/mysql-instance] All handlers succeeded for deletion.
[2020-06-14 12:38:36,283] kopf.objects         [INFO    ] [default/mysql-instance] Handler 'mysql_on_create' succeeded.
[2020-06-14 12:38:36,284] kopf.objects         [INFO    ] [default/mysql-instance] All handlers succeeded for creation.
[2020-06-14 12:41:09,100] kopf.objects         [INFO    ] [default/mysql-instance] Handler 'delete_object_make_backup' succeeded.
[2020-06-14 12:41:09,101] kopf.objects         [INFO    ] [default/mysql-instance] All handlers succeeded for deletion.
[2020-06-14 12:41:34,111] kopf.objects         [INFO    ] [default/mysql-instance] Handler 'mysql_on_create' succeeded.
[2020-06-14 12:41:34,111] kopf.objects         [INFO    ] [default/mysql-instance] All handlers succeeded for creation.
[2020-06-14 12:43:08,513] kopf.objects         [INFO    ] [default/mysql-instance] Handler 'delete_object_make_backup' succeeded.
[2020-06-14 12:43:08,514] kopf.objects         [INFO    ] [default/mysql-instance] All handlers succeeded for deletion.
[2020-06-14 12:43:38,776] kopf.objects         [INFO    ] [default/mysql-instance] Handler 'mysql_on_create' succeeded.
[2020-06-14 12:43:38,776] kopf.objects         [INFO    ] [default/mysql-instance] All handlers succeeded for creation.
kirsan@msi ~/Documents/OTUS/HW/Shtriga_platform/kubernetes-operators/deploy $ 

```

## PR checklist:
 - [X] Выставлен label с темой домашнего задания
